### PR TITLE
b/342257093 Enable DPI awareness in manifest

### DIFF
--- a/wwauth/Google.Solutions.WWAuth/App.config
+++ b/wwauth/Google.Solutions.WWAuth/App.config
@@ -3,8 +3,4 @@
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/>
     </startup>
-
-  <System.Windows.Forms.ApplicationConfigurationSection>
-    <add key="DpiAwareness" value="PerMonitorV2" />
-  </System.Windows.Forms.ApplicationConfigurationSection>
 </configuration>

--- a/wwauth/Google.Solutions.WWAuth/Google.Solutions.WWAuth.csproj
+++ b/wwauth/Google.Solutions.WWAuth/Google.Solutions.WWAuth.csproj
@@ -11,6 +11,7 @@
     <Company>Google LLC</Company>
     <Copyright>Google LLC</Copyright>
     <Product>Workload Authenticator for Windows</Product>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Google.Apis" Version="1.64.0" />

--- a/wwauth/Google.Solutions.WWAuth/app.manifest
+++ b/wwauth/Google.Solutions.WWAuth/app.manifest
@@ -11,20 +11,16 @@
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
-      <!-- A list of the Windows versions that this application has been tested on
-           and is designed to work with. Uncomment the appropriate elements
-           and Windows will automatically select the most compatible environment. -->
-
-      <!-- Windows 8 -->
-      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
-
-      <!-- Windows 8.1 -->
-      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
-
       <!-- Windows 10 -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
     </application>
   </compatibility>
+
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </windowsSettings>
+  </application>
 
   <dependency>
     <dependentAssembly>


### PR DESCRIPTION
Enable DPI awareness in app manifest instead of app.config so that wwauth.exe can be shipped standalone.