### PR TITLE
Update Docker base image

### DIFF
--- a/token-service/Dockerfile
+++ b/token-service/Dockerfile
@@ -22,7 +22,7 @@
 #
 # Build stage.
 #
-FROM maven:3.9-eclipse-temurin-8-alpine AS build
+FROM maven:3.9-eclipse-temurin-22-alpine AS build
 WORKDIR /app
 
 # Copy local code to the container image.


### PR DESCRIPTION
Use "maven:3.9-eclipse-temurin-22-alpine", fixing dependabot's botched update.